### PR TITLE
Add globals.node to ESLint config to support process.env

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,5 +5,5 @@ import { defineConfig } from "eslint/config";
 
 export default defineConfig([
   { files: ["**/*.{js,mjs,cjs}"], plugins: { js }, extends: ["js/recommended"] },
-  { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: globals.browser } },
+  { files: ["**/*.{js,mjs,cjs}"], languageOptions: { globals: globals.node } },
 ]);


### PR DESCRIPTION
Added globals.node to ESLint config to support process.env usage.